### PR TITLE
api-version 调整

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AutoUpdatePlugins
 version: '${project.version}'
 main: io.github.aplini.autoupdateplugins.AutoUpdatePlugins
-api-version: '1.20'
+api-version: '1.16'
 folia-supported: true
 prefix: AUP
 author: ApliNi


### PR DESCRIPTION
经测试 AUP 是完全支持 1.16.5 版本的（可能更低版本也支持），建议下调 api-version 的值
![屏幕截图 2024-05-24 214153](https://github.com/ApliNi/AutoUpdatePlugins/assets/56720055/1c4ca0d7-026a-4ccd-a025-dac0cb994c50)
